### PR TITLE
fix/ci/docs: fix autosync deactivation, add chart auto-updater workflow and fix som typos on the README.adoc

### DIFF
--- a/.github/workflows/chart-update.yaml
+++ b/.github/workflows/chart-update.yaml
@@ -1,0 +1,46 @@
+---
+name: "chart-update"
+
+on:
+  schedule:
+  - cron: "0 7 * * 1-5"
+  
+  workflow_dispatch:
+    inputs:
+      update-strategy:
+        description: "Update strategy to use. Valid values are 'patch', 'minor' or 'major'"
+        type: choice
+        options:
+        - "patch"
+        - "minor"
+        - "major"
+        required: true
+      excluded-dependencies:
+        description: "Comma-separated list of dependencies to exclude from the update (i.e. 'dependency1,dependency2,dependency3')"
+        type: string
+        required: false
+        default: ""
+      dry-run:
+        description: "Activate dry-run mode"
+        type: boolean
+        required: false
+        default: true
+
+jobs:
+
+  chart-update-schedule:
+    if: ${{ github.event_name == 'schedule' }}
+    strategy:
+      matrix:
+        update-strategy: ["major", "minor"]
+    uses: camptocamp/devops-stack/.github/workflows/modules-chart-update.yaml@main
+    with:
+      update-strategy: ${{ matrix.update-strategy }}
+  
+  chart-update-manual:
+    if: ${{ github.event_name == 'workflow_dispatch' }}
+    uses: camptocamp/devops-stack/.github/workflows/modules-chart-update.yaml@main
+    with:
+      update-strategy: ${{ inputs.update-strategy }}
+      excluded-dependencies: ${{ inputs.excluded-dependencies }}
+      dry-run: ${{ inputs.dry-run }}

--- a/README.adoc
+++ b/README.adoc
@@ -216,11 +216,11 @@ The following providers are used by this module:
 
 - [[provider_random]] <<provider_random,random>> (>= 3)
 
+- [[provider_null]] <<provider_null,null>>
+
 - [[provider_utils]] <<provider_utils,utils>> (>= 1)
 
 - [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
-
-- [[provider_null]] <<provider_null,null>>
 
 === Resources
 

--- a/README.adoc
+++ b/README.adoc
@@ -1,6 +1,6 @@
 = devops-stack-module-longhorn
 // Document attributes to replace along the document
-:chart-version: 1.4.2
+:longhorn-chart-version: 1.4.2
 :original-repo-url: https://github.com/longhorn/longhorn
 
 A https://devops-stack.io[DevOps Stack] module to deploy and configure https://longhorn.io/[Longhorn].
@@ -10,7 +10,7 @@ The Longhorn chart used by this module is shipped in this repository as well, in
 [cols="1,1,1",options="autowidth,header"]
 |===
 |Current Chart Version |Original Repository |Default Values
-|*{chart-version}* |{original-repo-url}/tree/master/chart[Chart] | https://artifacthub.io/packages/helm/longhorn/longhorn/{chart-version}?modal=values[`values.yaml`]
+|*{longhorn-chart-version}* |{original-repo-url}/tree/master/chart[Chart] | https://artifacthub.io/packages/helm/longhorn/longhorn/{chart-version}?modal=values[`values.yaml`]
 |===
 
 IMPORTANT: For the moment, this module only supports the deployment of Longhorn in SKS clusters.

--- a/README.adoc
+++ b/README.adoc
@@ -35,7 +35,7 @@ module "longhorn" {
 }
 ----
 
-You can enable the ingress to the Longhorn Dashboard. In that case, you will need to enable the respective flag and pass along the require OIDC configuration:
+You can enable the ingress to the Longhorn Dashboard. In that case, you will need to enable the respective flag and pass along the required OIDC configuration:
 
 [source,terraform]
 ----
@@ -59,7 +59,7 @@ module "longhorn" {
   }
 ----
 
-NOTE: The previous example uses xref:keycloak:ROOT:README.adoc[Keycloak] as an OIDC provider, but you can any other you want.
+NOTE: The previous example uses xref:keycloak:ROOT:README.adoc[Keycloak] as an OIDC provider, but you can use any other you want.
 
 In case you want to backup the content of the persistent volumes, you have the possibility of enabling the backup feature. In that case, you will need to enable the respective flag and pass along the require S3 configuration:
 

--- a/README.adoc
+++ b/README.adoc
@@ -275,7 +275,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v2.0.0"`
+Default: `"v2.1.0"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -551,7 +551,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v2.0.0"`
+|`"v2.1.0"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>

--- a/charts/longhorn/Chart.yaml
+++ b/charts/longhorn/Chart.yaml
@@ -4,5 +4,5 @@ name: "longhorn"
 version: "0"
 dependencies:
   - name: "longhorn"
-    version: "^1"
+    version: "1.4.2"
     repository: "https://charts.longhorn.io"

--- a/main.tf
+++ b/main.tf
@@ -66,10 +66,13 @@ resource "argocd_application" "this" {
     }
 
     sync_policy {
-      automated {
-        prune       = var.app_autosync.prune
-        self_heal   = var.app_autosync.self_heal
-        allow_empty = var.app_autosync.allow_empty
+      dynamic "automated" {
+        for_each = toset(var.app_autosync == { "allow_empty" = tobool(null), "prune" = tobool(null), "self_heal" = tobool(null) } ? [] : [var.app_autosync])
+        content {
+          prune       = automated.value.prune
+          self_heal   = automated.value.self_heal
+          allow_empty = automated.value.allow_empty
+        }
       }
 
       retry {


### PR DESCRIPTION
## Description of the changes

This PR:
- re-adds the support to deactivate the auto-sync, which was broken by the use of dynamic Terraform blocks on the PR #6. This is not a breaking change, because users can still use the old way of passing an empty map to the `app_autosync` variable in order do deactivate the auto-sync.
- adds the workflow that enables the auto-upgrade of the Helm charts.
- fix some typos on the README.adoc.

:warning: **Do a _Rebase and merge_**

## Breaking change

- [x] No

## Tests executed on which distribution(s)

- [x] SKS (Exoscale)