### PR TITLE
feat: parameterize backup and replicas settings and tweak default values

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -216,11 +216,11 @@ The following providers are used by this module:
 
 - [[provider_random]] <<provider_random,random>> (>= 3)
 
-- [[provider_null]] <<provider_null,null>>
-
 - [[provider_utils]] <<provider_utils,utils>> (>= 1)
 
 - [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
+
+- [[provider_null]] <<provider_null,null>>
 
 === Resources
 
@@ -275,7 +275,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v2.1.0"`
+Default: `"v2.1.1"`
 
 ==== [[input_namespace]] <<input_namespace,namespace>>
 
@@ -327,11 +327,11 @@ Default: `{}`
 
 ==== [[input_storage_over_provisioning_percentage]] <<input_storage_over_provisioning_percentage,storage_over_provisioning_percentage>>
 
-Description: Set the storage over-provisioning percentage. **This values should be modified only when really needed.** The default is 200%, as https://longhorn.io/docs/1.3.1/best-practices/#minimal-available-storage-and-over-provisioning[recommended in the best practices] for single-disk nodes.
+Description: Set the storage over-provisioning percentage. **This values should be modified only when really needed.**
 
 Type: `number`
 
-Default: `200`
+Default: `100`
 
 ==== [[input_storage_minimal_available_percentage]] <<input_storage_minimal_available_percentage,storage_minimal_available_percentage>>
 
@@ -378,17 +378,23 @@ Default: `null`
 ==== [[input_backup_configuration]] <<input_backup_configuration,backup_configuration>>
 
 Description: The following values can be configured:
+. `snapshot_enabled` - Enable Longhorn automatic snapshots.
 . `snapshot_cron` - Cron schedule to configure Longhorn automatic snapshots.
 . `snapshot_retention` - Retention of Longhorn automatic snapshots in days.
+. `backup_enabled` - Enable Longhorn automatic backups to object storage.
 . `backup_cron` - Cron schedule to configure Longhorn automatic backups.
 . `backup_retention` - Retention of Longhorn automatic backups in days.
+
+/!\ These settings cannot be changed after StorageClass creation without having to recreate it!
 
 Type:
 [source,hcl]
 ----
 object({
+    snapshot_enabled   = bool
     snapshot_cron      = string
     snapshot_retention = number
+    backup_enabled     = bool
     backup_cron        = string
     backup_retention   = number
   })
@@ -399,8 +405,10 @@ Default:
 ----
 {
   "backup_cron": "30 */12 * * *",
+  "backup_enabled": false,
   "backup_retention": "2",
   "snapshot_cron": "0 */2 * * *",
+  "snapshot_enabled": false,
   "snapshot_retention": "1"
 }
 ----
@@ -449,9 +457,17 @@ object({
 
 Default: `null`
 
+==== [[input_replica_count]] <<input_replica_count,replica_count>>
+
+Description: Amount of replicas created by Longhorn for each volume.
+
+Type: `number`
+
+Default: `2`
+
 ==== [[input_tolerations]] <<input_tolerations,tolerations>>
 
-Description: Tolerations to be added to the core Longhorn components that manage storage on nodes. **These tolerations are required if you want Longhorn to schedule storage on nodes that are tainted.**  
+Description: Tolerations to be added to the core Longhorn components that manage storage on nodes. **These tolerations are required if you want Longhorn to schedule storage on nodes that are tainted.**
 
 These settings only have an effect on the first deployment. If added at a later time, you need to also add them on the _Settings_ tab in the Longhorn Dashboard. Check the https://longhorn.io/docs/latest/advanced-resources/deploy/taint-toleration/[official documentation] for more detailed information.
 
@@ -551,7 +567,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v2.1.0"`
+|`"v2.1.1"`
 |no
 
 |[[input_namespace]] <<input_namespace,namespace>>
@@ -599,9 +615,9 @@ object({
 |no
 
 |[[input_storage_over_provisioning_percentage]] <<input_storage_over_provisioning_percentage,storage_over_provisioning_percentage>>
-|Set the storage over-provisioning percentage. **This values should be modified only when really needed.** The default is 200%, as https://longhorn.io/docs/1.3.1/best-practices/#minimal-available-storage-and-over-provisioning[recommended in the best practices] for single-disk nodes.
+|Set the storage over-provisioning percentage. **This values should be modified only when really needed.**
 |`number`
-|`200`
+|`100`
 |no
 
 |[[input_storage_minimal_available_percentage]] <<input_storage_minimal_available_percentage,storage_minimal_available_percentage>>
@@ -642,18 +658,24 @@ object({
 
 |[[input_backup_configuration]] <<input_backup_configuration,backup_configuration>>
 |The following values can be configured:
+. `snapshot_enabled` - Enable Longhorn automatic snapshots.
 . `snapshot_cron` - Cron schedule to configure Longhorn automatic snapshots.
 . `snapshot_retention` - Retention of Longhorn automatic snapshots in days.
+. `backup_enabled` - Enable Longhorn automatic backups to object storage.
 . `backup_cron` - Cron schedule to configure Longhorn automatic backups.
 . `backup_retention` - Retention of Longhorn automatic backups in days.
+
+/!\ These settings cannot be changed after StorageClass creation without having to recreate it!
 
 |
 
 [source]
 ----
 object({
+    snapshot_enabled   = bool
     snapshot_cron      = string
     snapshot_retention = number
+    backup_enabled     = bool
     backup_cron        = string
     backup_retention   = number
   })
@@ -665,8 +687,10 @@ object({
 ----
 {
   "backup_cron": "30 */12 * * *",
+  "backup_enabled": false,
   "backup_retention": "2",
   "snapshot_cron": "0 */2 * * *",
+  "snapshot_enabled": false,
   "snapshot_retention": "1"
 }
 ----
@@ -711,9 +735,15 @@ object({
 |`null`
 |no
 
+|[[input_replica_count]] <<input_replica_count,replica_count>>
+|Amount of replicas created by Longhorn for each volume.
+|`number`
+|`2`
+|no
+
 |[[input_tolerations]] <<input_tolerations,tolerations>>
 |Tolerations to be added to the core Longhorn components that manage storage on nodes. **These tolerations are required if you want Longhorn to schedule storage on nodes that are tainted.**
-    
+
 These settings only have an effect on the first deployment. If added at a later time, you need to also add them on the _Settings_ tab in the Longhorn Dashboard. Check the https://longhorn.io/docs/latest/advanced-resources/deploy/taint-toleration/[official documentation] for more detailed information.
 
 **Only tolerations with the "Equal" operator are supported**, because the Longhorn Helm chart expects a parsed list as a string in the `defaultSettings.taintToleration` value.

--- a/charts/longhorn/templates/backup-storageclass.yaml
+++ b/charts/longhorn/templates/backup-storageclass.yaml
@@ -13,22 +13,29 @@ reclaimPolicy: Delete
 volumeBindingMode: Immediate
 parameters:
   dataLocality: "disabled"
-  numberOfReplicas: "3"
+  numberOfReplicas: {{ $.Values.numberOfReplicas | quote }}
   staleReplicaTimeout: "30"
   fromBackup: ""
   recurringJobs: '[
+    {{- if $.Values.backups.config.snapshot_enabled }}
     {
       "name":"snapshot",
       "task":"snapshot",
       "cron": "{{ $.Values.backups.config.snapshot_cron }}",
       "retain": {{ $.Values.backups.config.snapshot_retention }}
-    },
+    }
+    {{- end -}}
+    {{- if and $.Values.backups.config.backup_enabled $.Values.backups.config.snapshot_enabled -}}
+    ,
+    {{ end -}}
+    {{- if $.Values.backups.config.backup_enabled -}}
     {
       "name":"backup",
       "task":"backup",
       "cron": "{{ $.Values.backups.config.backup_cron }}",
       "retain": {{ $.Values.backups.config.backup_retention }}
     }
+    {{- end }}
   ]'
 
 {{- end }}

--- a/locals.tf
+++ b/locals.tf
@@ -18,7 +18,8 @@ locals {
         taintToleration                   = join(";", local.tolerations_list)
       }
       persistence = {
-        defaultClass = var.enable_pv_backups && var.set_default_storage_class ? "false" : "true"
+        defaultClass             = var.enable_pv_backups && var.set_default_storage_class ? "false" : "true"
+        defaultClassReplicaCount = var.replica_count
       }
       longhornManager = {
         tolerations = var.tolerations
@@ -31,6 +32,7 @@ locals {
       config              = var.backup_configuration
       storage             = var.backup_storage
     } : null)
+    numberOfReplicas = var.replica_count
     oidc = var.oidc != null ? {
       oauth2_proxy_image      = "quay.io/oauth2-proxy/oauth2-proxy:v7.4.0"
       issuer_url              = var.oidc.issuer_url

--- a/variables.tf
+++ b/variables.tf
@@ -69,9 +69,9 @@ variable "dependency_ids" {
 #######################
 
 variable "storage_over_provisioning_percentage" {
-  description = "Set the storage over-provisioning percentage. **This values should be modified only when really needed.** The default is 200%, as https://longhorn.io/docs/1.3.1/best-practices/#minimal-available-storage-and-over-provisioning[recommended in the best practices] for single-disk nodes."
+  description = "Set the storage over-provisioning percentage. **This values should be modified only when really needed.**"
   type        = number
-  default     = 200
+  default     = 100
 }
 
 variable "storage_minimal_available_percentage" {
@@ -107,22 +107,30 @@ variable "backup_storage" {
 variable "backup_configuration" {
   description = <<-EOT
     The following values can be configured:
+    . `snapshot_enabled` - Enable Longhorn automatic snapshots.
     . `snapshot_cron` - Cron schedule to configure Longhorn automatic snapshots.
     . `snapshot_retention` - Retention of Longhorn automatic snapshots in days.
+    . `backup_enabled` - Enable Longhorn automatic backups to object storage.
     . `backup_cron` - Cron schedule to configure Longhorn automatic backups.
     . `backup_retention` - Retention of Longhorn automatic backups in days.
+
+    /!\ These settings cannot be changed after StorageClass creation without having to recreate it!
   EOT
 
   type = object({
+    snapshot_enabled   = bool
     snapshot_cron      = string
     snapshot_retention = number
+    backup_enabled     = bool
     backup_cron        = string
     backup_retention   = number
   })
 
   default = {
+    snapshot_enabled   = false
     snapshot_cron      = "0 */2 * * *"
     snapshot_retention = "1"
+    backup_enabled     = false
     backup_cron        = "30 */12 * * *"
     backup_retention   = "2"
   }
@@ -160,10 +168,16 @@ variable "oidc" {
   default = null
 }
 
+variable "replica_count" {
+  description = "Amount of replicas created by Longhorn for each volume."
+  type        = number
+  default     = 2
+}
+
 variable "tolerations" {
   description = <<-EOT
     Tolerations to be added to the core Longhorn components that manage storage on nodes. **These tolerations are required if you want Longhorn to schedule storage on nodes that are tainted.**
-    
+
     These settings only have an effect on the first deployment. If added at a later time, you need to also add them on the _Settings_ tab in the Longhorn Dashboard. Check the https://longhorn.io/docs/latest/advanced-resources/deploy/taint-toleration/[official documentation] for more detailed information.
 
     **Only tolerations with the "Equal" operator are supported**, because the Longhorn Helm chart expects a parsed list as a string in the `defaultSettings.taintToleration` value.


### PR DESCRIPTION
## Description of the changes

- Disable overprovisioning by default
- Parameterize backup/snapshot activation and disable them by default 
- Parameterize volume replica count and lower it to 2 by default 

All these changes are done to avoid uncontrolled storage usage with default setup and to allow more flexibility in configuration

## Breaking change

- [X] No
- [ ] Yes (in the Helm chart(s)): _indicate the chart, version & release note link_
- [ ] Yes (in the module itself): _give an explanation of the breaking change_

## Tests executed on which distribution(s)

- [ ] KinD
- [ ] AKS (Azure)
- [ ] EKS (AWS)
- [ ] Scaleway
- [X] SKS (Exoscale)