### PR TITLE
feat: add variable for additional alerts labels

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -437,6 +437,14 @@ Type: `bool`
 
 Default: `false`
 
+==== [[input_additional_alert_labels]] <<input_additional_alert_labels,additional_alert_labels>>
+
+Description: Additional labels to add to Longhorn alerts.
+
+Type: `map(string)`
+
+Default: `{}`
+
 ==== [[input_enable_dashboard_ingress]] <<input_enable_dashboard_ingress,enable_dashboard_ingress>>
 
 Description: Boolean to enable the creation of an ingress for the Longhorn's dashboard. **If enabled, you must provide a value for `base_domain`.**
@@ -768,6 +776,12 @@ object({
 |Boolean to enable the deployment of a service monitor.
 |`bool`
 |`false`
+|no
+
+|[[input_additional_alert_labels]] <<input_additional_alert_labels,additional_alert_labels>>
+|Additional labels to add to Longhorn alerts.
+|`map(string)`
+|`{}`
 |no
 
 |[[input_enable_dashboard_ingress]] <<input_enable_dashboard_ingress,enable_dashboard_ingress>>

--- a/charts/longhorn/templates/prometheus-rules.yaml
+++ b/charts/longhorn/templates/prometheus-rules.yaml
@@ -19,6 +19,9 @@ spec:
       for: 5m
       labels:
         severity: warning
+        {{- with $.Values.servicemonitor.additionalAlertLabels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
     - alert: LonghornVolumeStatusCritical
       annotations:
         description: {{"Longhorn volume {{$labels.volume}} on {{$labels.node}} is Fault for more than 2 minutes."}}
@@ -27,6 +30,9 @@ spec:
       for: 5m
       labels:
         severity: critical
+        {{- with $.Values.servicemonitor.additionalAlertLabels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
     - alert: LonghornVolumeStatusWarning
       annotations:
         description: {{"Longhorn volume {{$labels.volume}} on {{$labels.node}} is Degraded for more than 5 minutes."}}
@@ -35,6 +41,9 @@ spec:
       for: 5m
       labels:
         severity: warning
+        {{- with $.Values.servicemonitor.additionalAlertLabels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
     - alert: LonghornNodeStorageWarning
       annotations:
         description: {{"The used storage of node {{$labels.node}} is at {{$value}}% capacity for more than 5 minutes."}}
@@ -43,6 +52,9 @@ spec:
       for: 5m
       labels:
         severity: warning
+        {{- with $.Values.servicemonitor.additionalAlertLabels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
     - alert: LonghornDiskStorageWarning
       annotations:
         description: {{"The used storage of disk {{$labels.disk}} on node {{$labels.node}} is at {{$value}}% capacity for more than 5 minutes."}}
@@ -51,6 +63,9 @@ spec:
       for: 5m
       labels:
         severity: warning
+        {{- with $.Values.servicemonitor.additionalAlertLabels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
     - alert: LonghornNodeDown
       annotations:
         description: {{"There are {{$value}} Longhorn nodes which have been offline for more than 5 minutes."}}
@@ -59,6 +74,9 @@ spec:
       for: 5m
       labels:
         severity: critical
+        {{- with $.Values.servicemonitor.additionalAlertLabels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
     - alert: LonghornIntanceManagerCPUUsageWarning
       annotations:
         description: {{"Longhorn instance manager {{$labels.instance_manager}} on {{$labels.node}} has CPU Usage / CPU request is {{$value}}% for more than 5 minutes."}}
@@ -67,6 +85,9 @@ spec:
       for: 5m
       labels:
         severity: warning
+        {{- with $.Values.servicemonitor.additionalAlertLabels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
     - alert: LonghornNodeCPUUsageWarning
       annotations:
         description: {{"Longhorn node {{$labels.node}} has CPU Usage / CPU capacity is {{$value}}% for more than 5 minutes."}}
@@ -75,5 +96,8 @@ spec:
       for: 5m
       labels:
         severity: warning
+        {{- with $.Values.servicemonitor.additionalAlertLabels }}
+          {{- toYaml . | nindent 8 }}
+        {{- end }}
 
 {{- end -}}

--- a/locals.tf
+++ b/locals.tf
@@ -69,6 +69,7 @@ locals {
     }
     servicemonitor = {
       enabled = var.enable_service_monitor
+      additionalAlertLabels = var.additional_alert_labels
     }
     automaticFilesystemTrim = {
       enabled   = var.automatic_filesystem_trim.enabled

--- a/variables.tf
+++ b/variables.tf
@@ -154,6 +154,12 @@ variable "enable_service_monitor" {
   default     = false
 }
 
+variable "additional_alert_labels" {
+  description = "Additional labels to add to Longhorn alerts."
+  type        = map(string)
+  default     = {}
+}
+
 variable "enable_dashboard_ingress" {
   description = "Boolean to enable the creation of an ingress for the Longhorn's dashboard. **If enabled, you must provide a value for `base_domain`.**"
   type        = bool


### PR DESCRIPTION
## Description of the changes

Add the possibility to add custom alert labels using Terraform variable.
We need it to be able to correctly route alerts to our slack.

## Breaking change

- [x] No

## Tests executed on which distribution(s)

- [x] SKS (Exoscale)