### PR TITLE
feat: add automatic filesystem trim feature using recurringjob

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -291,7 +291,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v3.0.0"`
+Default: `"v3.1.0"`
 
 ==== [[input_helm_values]] <<input_helm_values,helm_values>>
 
@@ -473,6 +473,45 @@ object({
 
 Default: `null`
 
+==== [[input_automatic_filesystem_trim]] <<input_automatic_filesystem_trim,automatic_filesystem_trim>>
+
+Description: Settings to enable and configure automatic filesystem trim of volumes managed by Longhorn.
+
+Type:
+[source,hcl]
+----
+object({
+    enabled   = bool
+    cron      = string
+    job_group = string
+  })
+----
+
+Default:
+[source,json]
+----
+{
+  "cron": "0 6 * * *",
+  "enabled": false,
+  "job_group": ""
+}
+----
+
+==== [[input_recurring_job_selectors]] <<input_recurring_job_selectors,recurring_job_selectors>>
+
+Description: Define a group list to add to recurring job selector for the default storage class (the custom backup one if `set_default_storage_class` is set or else the Longhorn default one).
+
+Type:
+[source,hcl]
+----
+list(object({
+    name    = string
+    isGroup = bool
+  }))
+----
+
+Default: `null`
+
 ==== [[input_replica_count]] <<input_replica_count,replica_count>>
 
 Description: Amount of replicas created by Longhorn for each volume.
@@ -595,7 +634,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v3.0.0"`
+|`"v3.1.0"`
 |no
 
 |[[input_helm_values]] <<input_helm_values,helm_values>>
@@ -758,6 +797,47 @@ object({
     client_secret           = string
     oauth2_proxy_extra_args = optional(list(string), [])
   })
+----
+
+|`null`
+|no
+
+|[[input_automatic_filesystem_trim]] <<input_automatic_filesystem_trim,automatic_filesystem_trim>>
+|Settings to enable and configure automatic filesystem trim of volumes managed by Longhorn.
+|
+
+[source]
+----
+object({
+    enabled   = bool
+    cron      = string
+    job_group = string
+  })
+----
+
+|
+
+[source]
+----
+{
+  "cron": "0 6 * * *",
+  "enabled": false,
+  "job_group": ""
+}
+----
+
+|no
+
+|[[input_recurring_job_selectors]] <<input_recurring_job_selectors,recurring_job_selectors>>
+|Define a group list to add to recurring job selector for the default storage class (the custom backup one if `set_default_storage_class` is set or else the Longhorn default one).
+|
+
+[source]
+----
+list(object({
+    name    = string
+    isGroup = bool
+  }))
 ----
 
 |`null`

--- a/charts/longhorn/templates/backup-storageclass.yaml
+++ b/charts/longhorn/templates/backup-storageclass.yaml
@@ -16,6 +16,12 @@ parameters:
   numberOfReplicas: {{ $.Values.numberOfReplicas | quote }}
   staleReplicaTimeout: "30"
   fromBackup: ""
+  {{- if $.Values.recurringJobSelector }}
+  recurringJobSelector: 
+  {{- with $.Values.recurringJobSelector }}
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- end }}
   recurringJobs: '[
     {{- if $.Values.backups.config.snapshot_enabled }}
     {

--- a/charts/longhorn/templates/recurring-job-filesystem-trim.yaml
+++ b/charts/longhorn/templates/recurring-job-filesystem-trim.yaml
@@ -1,0 +1,24 @@
+{{- if $.Values.automaticFilesystemTrim.enabled -}}
+
+---
+apiVersion: longhorn.io/v1beta2
+kind: RecurringJob
+metadata:
+  name: {{ $.Release.Name }}-filesystem-trim
+  labels:
+    name: {{ $.Release.Name }}-filesystem-trim
+spec:
+  concurrency: 1
+  cron: {{ $.Values.automaticFilesystemTrim.cron | quote }}
+  {{- if and ($.Values.automaticFilesystemTrim.jobGroup) (ne $.Values.automaticFilesystemTrim.jobGroup "") }}
+  groups:
+    - {{ $.Values.automaticFilesystemTrim.jobGroup | quote }}
+  {{- else }}
+  groups: []
+  {{- end }}
+  labels: {}
+  name: fs-trim
+  retain: 0
+  task: filesystem-trim
+
+{{- end -}}

--- a/variables.tf
+++ b/variables.tf
@@ -180,6 +180,29 @@ variable "oidc" {
   default = null
 }
 
+variable "automatic_filesystem_trim" {
+  description = "Settings to enable and configure automatic filesystem trim of volumes managed by Longhorn."
+  type = object({
+    enabled   = bool
+    cron      = string
+    job_group = string
+  })
+  default = {
+    enabled   = false
+    cron      = "0 6 * * *"
+    job_group = ""
+  }
+}
+
+variable "recurring_job_selectors" {
+  description = "Define a group list to add to recurring job selector for the default storage class (the custom backup one if `set_default_storage_class` is set or else the Longhorn default one)."
+  type = list(object({
+    name    = string
+    isGroup = bool
+  }))
+  default = null
+}
+
 variable "replica_count" {
   description = "Amount of replicas created by Longhorn for each volume."
   type        = number


### PR DESCRIPTION
## Description of the changes

Add feature to enable automatic filesystem trim on volumes using **recurringjob** and add **recurringjob** selectors on the default storageclass.
**:warning:  Need #21 to be merged**

## Breaking change

- [x] No
- [ ] Yes (in the Helm chart(s)): _indicate the chart, version & release note link_
- [ ] Yes (in the module itself): _give an explanation of the breaking change_

## Tests executed on which distribution(s)

- [ ] KinD
- [ ] AKS (Azure)
- [ ] EKS (AWS)
- [ ] Scaleway
- [x] SKS (Exoscale)