### PR TITLE
feat: add a subdomain variable

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -216,11 +216,11 @@ The following providers are used by this module:
 
 - [[provider_random]] <<provider_random,random>> (>= 3)
 
+- [[provider_null]] <<provider_null,null>>
+
 - [[provider_utils]] <<provider_utils,utils>> (>= 1)
 
 - [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
-
-- [[provider_null]] <<provider_null,null>>
 
 === Resources
 

--- a/README.adoc
+++ b/README.adoc
@@ -253,6 +253,14 @@ Type: `string`
 
 Default: `null`
 
+==== [[input_subdomain]] <<input_subdomain,subdomain>>
+
+Description: Sub domain of the cluster. Value used for the ingress' URL of the application.
+
+Type: `string`
+
+Default: `"apps"`
+
 ==== [[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 
 Description: SSL certificate issuer to use. Usually you would configure this value as `letsencrypt-staging` or `letsencrypt-prod` on your root `*.tf` files.
@@ -291,7 +299,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v3.2.0"`
+Default: `"v3.2.1"`
 
 ==== [[input_helm_values]] <<input_helm_values,helm_values>>
 
@@ -615,6 +623,12 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |`null`
 |no
 
+|[[input_subdomain]] <<input_subdomain,subdomain>>
+|Sub domain of the cluster. Value used for the ingress' URL of the application.
+|`string`
+|`"apps"`
+|no
+
 |[[input_cluster_issuer]] <<input_cluster_issuer,cluster_issuer>>
 |SSL certificate issuer to use. Usually you would configure this value as `letsencrypt-staging` or `letsencrypt-prod` on your root `*.tf` files.
 |`string`
@@ -642,7 +656,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v3.2.0"`
+|`"v3.2.1"`
 |no
 
 |[[input_helm_values]] <<input_helm_values,helm_values>>

--- a/README.adoc
+++ b/README.adoc
@@ -255,7 +255,7 @@ Default: `null`
 
 ==== [[input_subdomain]] <<input_subdomain,subdomain>>
 
-Description: Sub domain of the cluster. Value used for the ingress' URL of the application.
+Description: Subdomain of the cluster. Value used for the ingress' URL of the application.
 
 Type: `string`
 
@@ -624,7 +624,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |no
 
 |[[input_subdomain]] <<input_subdomain,subdomain>>
-|Sub domain of the cluster. Value used for the ingress' URL of the application.
+|Subdomain of the cluster. Value used for the ingress' URL of the application.
 |`string`
 |`"apps"`
 |no

--- a/locals.tf
+++ b/locals.tf
@@ -1,6 +1,6 @@
 locals {
-  domain      = format("longhorn.apps.%s", var.base_domain)
-  domain_full = format("longhorn.apps.%s.%s", var.cluster_name, var.base_domain)
+  domain      = format("longhorn.%s", trimprefix("${var.subdomain}.${var.base_domain}", "."))
+  domain_full = format("longhorn.%s.%s", trimprefix("${var.subdomain}.${var.cluster_name}", "."), var.base_domain)
 
   # Generate a list of tolerations in a string format of `key=value:effect` for all the tolerations that have
   # an `operator` equal to `Equal`. This list of strings will be joined to pass as the value of

--- a/locals.tf
+++ b/locals.tf
@@ -58,7 +58,6 @@ locals {
       annotations = {
         "cert-manager.io/cluster-issuer"                   = "${var.cluster_issuer}"
         "traefik.ingress.kubernetes.io/router.entrypoints" = "websecure"
-        "traefik.ingress.kubernetes.io/router.middlewares" = "traefik-withclustername@kubernetescrd"
         "traefik.ingress.kubernetes.io/router.tls"         = "true"
         "ingress.kubernetes.io/ssl-redirect"               = "true"
         "kubernetes.io/ingress.allow-http"                 = "false"

--- a/variables.tf
+++ b/variables.tf
@@ -14,6 +14,12 @@ variable "base_domain" {
   default     = null
 }
 
+variable "subdomain" {
+  description = "Sub domain of the cluster. Value used for the ingress' URL of the application."
+  type        = string
+  default     = "apps"
+}
+
 variable "cluster_issuer" {
   description = "SSL certificate issuer to use. Usually you would configure this value as `letsencrypt-staging` or `letsencrypt-prod` on your root `*.tf` files."
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -18,6 +18,7 @@ variable "subdomain" {
   description = "Subdomain of the cluster. Value used for the ingress' URL of the application."
   type        = string
   default     = "apps"
+  nullable    = false
 }
 
 variable "cluster_issuer" {

--- a/variables.tf
+++ b/variables.tf
@@ -15,7 +15,7 @@ variable "base_domain" {
 }
 
 variable "subdomain" {
-  description = "Sub domain of the cluster. Value used for the ingress' URL of the application."
+  description = "Subdomain of the cluster. Value used for the ingress' URL of the application."
   type        = string
   default     = "apps"
 }


### PR DESCRIPTION
## Description of the changes

Hello,

We have a need to use URLs without the .apps. part, in order to achieve that without introducing a breaking change we propose a new variable subdomain that defaults to apps, that way we can set it to an empty string on our side.

## Breaking change

- [X] No

## Tests executed on which distribution(s)

- [X] SKS (Exoscale)