### PR TITLE
fix: remove legacy ingress annotations

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -216,11 +216,11 @@ The following providers are used by this module:
 
 - [[provider_random]] <<provider_random,random>> (>= 3)
 
-- [[provider_null]] <<provider_null,null>>
-
 - [[provider_utils]] <<provider_utils,utils>> (>= 1)
 
 - [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
+
+- [[provider_null]] <<provider_null,null>>
 
 === Resources
 
@@ -299,7 +299,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v3.2.1"`
+Default: `"v3.3.0"`
 
 ==== [[input_helm_values]] <<input_helm_values,helm_values>>
 
@@ -588,9 +588,9 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |===
 |Name |Version
 |[[provider_random]] <<provider_random,random>> |>= 3
+|[[provider_null]] <<provider_null,null>> |n/a
 |[[provider_utils]] <<provider_utils,utils>> |>= 1
 |[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
-|[[provider_null]] <<provider_null,null>> |n/a
 |===
 
 = Resources
@@ -656,7 +656,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v3.2.1"`
+|`"v3.3.0"`
 |no
 
 |[[input_helm_values]] <<input_helm_values,helm_values>>

--- a/locals.tf
+++ b/locals.tf
@@ -59,8 +59,6 @@ locals {
         "cert-manager.io/cluster-issuer"                   = "${var.cluster_issuer}"
         "traefik.ingress.kubernetes.io/router.entrypoints" = "websecure"
         "traefik.ingress.kubernetes.io/router.tls"         = "true"
-        "ingress.kubernetes.io/ssl-redirect"               = "true"
-        "kubernetes.io/ingress.allow-http"                 = "false"
       }
     }
     grafana_dashboard = {


### PR DESCRIPTION
## Description of the changes

The SSL redirection is no longer defined by these annotations, I think this is a leftover from ancient code. The HTTP -> HTTPS redirection is handled natively by the Traefik module and is enabled by default (a variable is available to deactivate it if necessary).

## Breaking change

- [x] No

## Tests executed on which distribution(s)

- [x] AKS (Azure)
- [x] EKS (AWS)
- [x] SKS (Exoscale)