### PR TITLE
fix/feat: fix upgrade check which was broken by the Longhorn chart v1.6.0 and upgrade the OAuth Proxy image

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -299,7 +299,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v3.3.0"`
+Default: `"v3.4.0"`
 
 ==== [[input_helm_values]] <<input_helm_values,helm_values>>
 
@@ -656,7 +656,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v3.3.0"`
+|`"v3.4.0"`
 |no
 
 |[[input_helm_values]] <<input_helm_values,helm_values>>

--- a/README.adoc
+++ b/README.adoc
@@ -588,9 +588,9 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |===
 |Name |Version
 |[[provider_random]] <<provider_random,random>> |>= 3
-|[[provider_null]] <<provider_null,null>> |n/a
 |[[provider_utils]] <<provider_utils,utils>> |>= 1
 |[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
+|[[provider_null]] <<provider_null,null>> |n/a
 |===
 
 = Resources

--- a/locals.tf
+++ b/locals.tf
@@ -41,7 +41,7 @@ locals {
     } : null)
     numberOfReplicas = var.replica_count
     oidc = var.oidc != null ? {
-      oauth2_proxy_image      = "quay.io/oauth2-proxy/oauth2-proxy:v7.5.0"
+      oauth2_proxy_image      = "quay.io/oauth2-proxy/oauth2-proxy:v7.6.0"
       issuer_url              = var.oidc.issuer_url
       redirect_url            = format("https://%s/oauth2/callback", local.domain_full)
       client_id               = var.oidc.client_id

--- a/locals.tf
+++ b/locals.tf
@@ -28,8 +28,8 @@ locals {
       longhornManager = {
         tolerations = var.tolerations
       }
-      helmPreUpgradeCheckerJob = {
-        enabled = var.enable_preupgrade_check
+      preUpgradeChecker = {
+        jobEnabled = var.enable_preupgrade_check
       }
     }
     backups = merge({


### PR DESCRIPTION
## Description of the changes

The last release of the Longhorn chart broke the boolean that disabled the pre-upgrade check, which is required for the first bootstrap of this component. This was something that I did not find in the release notes before so it escaped my tests.

This PR also upgrades the OAuth Proxy image.

:warning: **Do a _Rebase and merge_**

## Breaking change

- [x] No

## Tests executed on which distribution(s)

- [x] SKS (Exoscale)