### PR TITLE
fix: fix storage class creation when bootstrapping a cluster

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -216,11 +216,11 @@ The following providers are used by this module:
 
 - [[provider_random]] <<provider_random,random>> (>= 3)
 
-- [[provider_utils]] <<provider_utils,utils>> (>= 1)
+- [[provider_null]] <<provider_null,null>>
 
 - [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
 
-- [[provider_null]] <<provider_null,null>>
+- [[provider_utils]] <<provider_utils,utils>> (>= 1)
 
 === Resources
 
@@ -299,7 +299,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v3.4.0"`
+Default: `"v3.7.0"`
 
 ==== [[input_helm_values]] <<input_helm_values,helm_values>>
 
@@ -588,8 +588,8 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |===
 |Name |Version
 |[[provider_random]] <<provider_random,random>> |>= 3
-|[[provider_utils]] <<provider_utils,utils>> |>= 1
 |[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
+|[[provider_utils]] <<provider_utils,utils>> |>= 1
 |[[provider_null]] <<provider_null,null>> |n/a
 |===
 
@@ -656,7 +656,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v3.4.0"`
+|`"v3.7.0"`
 |no
 
 |[[input_helm_values]] <<input_helm_values,helm_values>>

--- a/charts/longhorn/templates/backup-storageclass.yaml
+++ b/charts/longhorn/templates/backup-storageclass.yaml
@@ -22,26 +22,5 @@ parameters:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   {{- end }}
-  recurringJobs: '[
-    {{- if $.Values.backups.config.snapshot_enabled }}
-    {
-      "name":"snapshot",
-      "task":"snapshot",
-      "cron": "{{ $.Values.backups.config.snapshot_cron }}",
-      "retain": {{ $.Values.backups.config.snapshot_retention }}
-    }
-    {{- end -}}
-    {{- if and $.Values.backups.config.backup_enabled $.Values.backups.config.snapshot_enabled -}}
-    ,
-    {{ end -}}
-    {{- if $.Values.backups.config.backup_enabled -}}
-    {
-      "name":"backup",
-      "task":"backup",
-      "cron": "{{ $.Values.backups.config.backup_cron }}",
-      "retain": {{ $.Values.backups.config.backup_retention }}
-    }
-    {{- end }}
-  ]'
 
 {{- end }}

--- a/charts/longhorn/templates/recurring-job-backup.yaml
+++ b/charts/longhorn/templates/recurring-job-backup.yaml
@@ -1,0 +1,20 @@
+{{- if $.Values.backups.enabled -}}
+{{- if $.Values.backups.config.backup_enabled -}}
+
+---
+apiVersion: longhorn.io/v1beta2
+kind: RecurringJob
+metadata:
+  name: {{ $.Release.Name }}-backup
+  labels:
+    name: {{ $.Release.Name }}-backup
+spec:
+  concurrency: 1
+  cron: {{ $.Values.backups.config.backup_cron | quote }}
+  labels: {}
+  name: backup
+  retain: {{ $.Values.backups.config.backup_retention }}
+  task: backup
+
+{{- end -}}
+{{- end -}}

--- a/charts/longhorn/templates/recurring-job-snapshot.yaml
+++ b/charts/longhorn/templates/recurring-job-snapshot.yaml
@@ -1,0 +1,20 @@
+{{- if $.Values.backups.enabled -}}
+{{- if $.Values.backups.config.snapshot_enabled -}}
+
+---
+apiVersion: longhorn.io/v1beta2
+kind: RecurringJob
+metadata:
+  name: {{ $.Release.Name }}-snapshot
+  labels:
+    name: {{ $.Release.Name }}-snapshot
+spec:
+  concurrency: 1
+  cron: {{ $.Values.backups.config.snapshot_cron | quote }}
+  labels: {}
+  name: backup
+  retain: {{ $.Values.backups.config.snapshot_retention }}
+  task: backup
+
+{{- end -}}
+{{- end -}}

--- a/locals.tf
+++ b/locals.tf
@@ -12,7 +12,6 @@ locals {
       defaultSettings = {
         backupTarget                      = var.enable_pv_backups ? format("s3://%s@%s/", var.backup_storage.bucket_name, var.backup_storage.region) : ""
         backupTargetCredentialSecret      = var.enable_pv_backups ? "longhorn-s3-secret" : ""
-        defaultLonghornStaticStorageClass = var.enable_pv_backups && var.set_default_storage_class ? "longhorn-backup" : "longhorn-static"
         storageOverProvisioningPercentage = var.storage_over_provisioning_percentage
         storageMinimalAvailablePercentage = var.storage_minimal_available_percentage
         taintToleration                   = join(";", local.tolerations_list)


### PR DESCRIPTION
## Description of the changes

### [feat: move recurring jobs to their own resources](https://github.com/camptocamp/devops-stack-module-longhorn/commit/43bd70250aaed0c6bf4cd2318bc53dd9a822b42f)

Instead of creating the recurring jobs from inside the StorageClass object, these are now created outside with their proper objects. They can still be selected to use by the StorageClass using the selectors that existed before.

### [fix: remove attribute causing issues when bootstrapping cluster](https://github.com/camptocamp/devops-stack-module-longhorn/commit/00f976ef7b09c6e0be82bd3be34b2516f67dd6aa)

When we set this attribute, Longhorn creates a prototype StorageClass that Argo CD is then unable to update with the configurations desired, giving an error message `The StorageClass "longhorn-backup" is invalid: parameters: Forbidden: updates to parameters are forbidden.`.

Removing the attribute `defaultLonghornStaticStorageClass` removes that problem while maintaining the normal behavior of the module, as the StorageClass is set as default by the annotation `storageclass.kubernetes.io/is-default-class: {{ $.Values.backups.defaultStorageClass | quote }}`.

:warning: **Do a _Rebase and merge_**

## Breaking change

- [x] No

## Tests executed on which distribution(s)

- [x] SKS (Exoscale)