### PR TITLE
Tweak alerts

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -216,11 +216,11 @@ The following providers are used by this module:
 
 - [[provider_random]] <<provider_random,random>> (>= 3)
 
-- [[provider_null]] <<provider_null,null>>
+- [[provider_utils]] <<provider_utils,utils>> (>= 1)
 
 - [[provider_argocd]] <<provider_argocd,argocd>> (>= 5)
 
-- [[provider_utils]] <<provider_utils,utils>> (>= 1)
+- [[provider_null]] <<provider_null,null>>
 
 === Resources
 
@@ -299,7 +299,7 @@ Description: Override of target revision of the application chart.
 
 Type: `string`
 
-Default: `"v3.7.0"`
+Default: `"v3.8.0"`
 
 ==== [[input_helm_values]] <<input_helm_values,helm_values>>
 
@@ -588,9 +588,9 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |===
 |Name |Version
 |[[provider_random]] <<provider_random,random>> |>= 3
+|[[provider_null]] <<provider_null,null>> |n/a
 |[[provider_argocd]] <<provider_argocd,argocd>> |>= 5
 |[[provider_utils]] <<provider_utils,utils>> |>= 1
-|[[provider_null]] <<provider_null,null>> |n/a
 |===
 
 = Resources
@@ -656,7 +656,7 @@ Description: ID to pass other modules in order to refer to this module as a depe
 |[[input_target_revision]] <<input_target_revision,target_revision>>
 |Override of target revision of the application chart.
 |`string`
-|`"v3.7.0"`
+|`"v3.8.0"`
 |no
 
 |[[input_helm_values]] <<input_helm_values,helm_values>>

--- a/charts/longhorn/templates/prometheus-rules.yaml
+++ b/charts/longhorn/templates/prometheus-rules.yaml
@@ -82,7 +82,7 @@ spec:
         description: {{"Longhorn instance manager {{$labels.instance_manager}} on {{$labels.node}} has CPU Usage / CPU request is {{$value}}% for more than 5 minutes."}}
         summary: {{"Longhorn instance manager {{$labels.instance_manager}} on {{$labels.node}} has CPU Usage / CPU request is over 300%."}}
       expr: (longhorn_instance_manager_cpu_usage_millicpu/longhorn_instance_manager_cpu_requests_millicpu) * 100 > 300
-      for: 5m
+      for: 1d
       labels:
         severity: warning
         {{- with $.Values.servicemonitor.additionalAlertLabels }}

--- a/charts/longhorn/templates/prometheus-rules.yaml
+++ b/charts/longhorn/templates/prometheus-rules.yaml
@@ -11,17 +11,6 @@ spec:
   groups:
   - name: longhorn.rules
     rules:
-    - alert: LonghornVolumeActualSpaceUsedWarning
-      annotations:
-        description: {{"The actual space used by Longhorn volume {{$labels.volume}} on {{$labels.node}} is at {{$value}}% capacity for more than 5 minutes."}}
-        summary: {{"The actual used space of Longhorn volume is over 90% of the capacity."}}
-      expr: (longhorn_volume_actual_size_bytes / longhorn_volume_capacity_bytes) * 100 > 90
-      for: 5m
-      labels:
-        severity: warning
-        {{- with $.Values.servicemonitor.additionalAlertLabels }}
-          {{- toYaml . | nindent 8 }}
-        {{- end }}
     - alert: LonghornVolumeStatusCritical
       annotations:
         description: {{"Longhorn volume {{$labels.volume}} on {{$labels.node}} is Fault for more than 2 minutes."}}


### PR DESCRIPTION
## Description of the changes

Adapt the LonghornIntanceManagerCPUUsageWarning to not take into account spikes.

Remove the LonghornVolumeActualSpaceUsedWarning Since the actual size can be bigger than capacity this alert
is not relevant (cf https://www.bookstack.cn/read/longhorn-1.7.1-en/f6cecc15d752a865.md)


## Breaking change

- [X] No
- [ ] Yes (in the Helm chart(s)): _indicate the chart, version & release note link_
- [ ] Yes (in the module itself): _give an explanation of the breaking change_

## Tests executed on which distribution(s)

- [ ] KinD
- [ ] AKS (Azure)
- [ ] EKS (AWS)
- [ ] Scaleway
- [X] SKS (Exoscale)